### PR TITLE
Add comments count function

### DIFF
--- a/src/services/DisqusService.php
+++ b/src/services/DisqusService.php
@@ -62,6 +62,49 @@ class DisqusService extends Component
 
         return $result;
     }
+    
+    /**
+     * Output the Disqus comments count
+     *
+     * @param string $disqusIdentifier
+     * @param string $disqusTitle
+     * @param string $disqusUrl
+     * @param string $disqusCategoryId
+     * @param string $disqusLanguage
+     *
+     * @return string
+     */
+    public function getCommentsCount(
+        $disqusIdentifier = "",
+        $disqusUrl = ""
+    ) {
+    
+      $settings = Disqus::$plugin->getSettings();
+      if (!empty($settings['disqusPublicKey'])){
+        $apiKey = $settings["disqusPublicKey"]; 
+      
+        $url = "https://disqus.com/api/3.0/threads/details.json?api_key=" . $apiKey . "&forum=" . $disqusIdentifier . "&thread:link=" . $disqusUrl;
+        
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, $url);
+        curl_setopt($ch, CURLOPT_HEADER, 0);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        $return = curl_exec($ch);
+        curl_close($ch);
+        
+        $json = json_decode($return, true);
+        if($json["code"] == 0){
+            return $json["response"]["posts"];
+        }else{
+          Craft::error(Craft::t('disqus', $json["response"]), __METHOD__);
+          return 0;
+        }
+      }else{
+        Craft::error(Craft::t('disqus', "Public API Key missing"), __METHOD__);
+        return 0;
+      }
+    
+    }
 
     // Protected Methods
     // =========================================================================

--- a/src/twigextensions/DisqusTwigExtension.php
+++ b/src/twigextensions/DisqusTwigExtension.php
@@ -40,6 +40,7 @@ class DisqusTwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFilter('disqusEmbed', [$this, 'disqusEmbed']),
+            new \Twig_SimpleFilter('disqusCount', [$this, 'disqusCount']),
         ];
     }
 
@@ -50,6 +51,7 @@ class DisqusTwigExtension extends \Twig_Extension
     {
         return [
             new \Twig_SimpleFunction('disqusEmbed', [$this, 'disqusEmbed']),
+            new \Twig_SimpleFunction('disqusCount', [$this, 'disqusCount']),
         ];
     }
 
@@ -75,6 +77,22 @@ class DisqusTwigExtension extends \Twig_Extension
             $disqusUrl,
             $disqusCategoryId,
             $disqusLanguage
+        );
+    }
+    
+    /**
+     * @param string $disqusIdentifier
+     * @param string $disqusUrl
+     *
+     * @return mixed
+     */    
+    public function disqusCount(
+        $disqusIdentifier = "",
+        $disqusUrl = ""
+    ) {
+        return Disqus::$plugin->disqusService->getCommentsCount(
+            $disqusIdentifier,
+            $disqusUrl
         );
     }
 }


### PR DESCRIPTION
Just output the comments count from a disqus thread:

```twig
{{ disqusCount("identifier", "permalink") }}
```

Needs curl for the api call. Maybe the call should be cached to avoid hitting the disqus api rate limit. 

Live preview: https://mdxdave.de/